### PR TITLE
Add `execute`, `get_policy` and `set_policy`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ env:
 script:
   - cargo build -v
   - sudo env "PATH=$PATH" cargo test -j 1 -- --nocapture
+  - sudo env "PATH=$PATH" cargo test -j 1 -- --nocapture --ignored

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,16 @@ impl IPTables {
         }
     }
 
+    /// Checks for the existence of the `chain` in the table.
+    /// Returns true if the chain exists.
+    #[cfg(target_os = "linux")]
+    pub fn chain_exists(&self, table: &str, chain: &str) -> IPTResult<bool> {
+        match self.run(&["-t", table, "-L", chain]) {
+            Ok(output) => Ok(output.status.success()),
+            Err(err) => Err(err),
+        }
+    }
+
     /// Inserts `rule` in the `position` to the table/chain.
     /// Returns `true` if the rule is inserted.
     pub fn insert(&self, table: &str, chain: &str, rule: &str, position: i32) -> IPTResult<bool> {

--- a/tests/iptables_test.rs
+++ b/tests/iptables_test.rs
@@ -1,5 +1,7 @@
 extern crate iptables;
 
+use std::panic;
+
 #[test]
 fn test_new() {
     nat(iptables::new(false).unwrap(), "NATNEW", "NATNEW2");
@@ -30,6 +32,9 @@ fn nat(ipt: iptables::IPTables, old_name: &str, new_name: &str) {
     assert_eq!(ipt.insert("nat", new_name, "-j ACCEPT", 1).unwrap(), true);
     assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), false);
+    assert!(ipt.execute("nat", &format!("-A {} -j ACCEPT", new_name)).is_ok());
+    assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
     assert_eq!(ipt.delete_chain("nat", new_name).unwrap(), true);
 }
 
@@ -41,5 +46,63 @@ fn filter(ipt: iptables::IPTables, name: &str) {
     assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), false);
     assert_eq!(ipt.delete("filter", name, "-j DROP").unwrap(), true);
     assert_eq!(ipt.list("filter", name).unwrap().len(), 1);
+    assert!(ipt.execute("filter", &format!("-A {} -j ACCEPT", name)).is_ok());
+    assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.flush_chain("filter", name).unwrap(), true);
     assert_eq!(ipt.delete_chain("filter", name).unwrap(), true);
+}
+
+#[test]
+fn test_get_policy() {
+    let ipt = iptables::new(false).unwrap();
+
+    // filter
+    assert!(ipt.get_policy("filter", "INPUT").is_ok());
+    assert!(ipt.get_policy("filter", "FORWARD").is_ok());
+    assert!(ipt.get_policy("filter", "OUTPUT").is_ok());
+    // mangle
+    assert!(ipt.get_policy("mangle", "PREROUTING").is_ok());
+    assert!(ipt.get_policy("mangle", "OUTPUT").is_ok());
+    assert!(ipt.get_policy("mangle", "INPUT").is_ok());
+    assert!(ipt.get_policy("mangle", "FORWARD").is_ok());
+    assert!(ipt.get_policy("mangle", "POSTROUTING").is_ok());
+    // nat
+    assert!(ipt.get_policy("nat", "PREROUTING").is_ok());
+    assert!(ipt.get_policy("nat", "POSTROUTING").is_ok());
+    assert!(ipt.get_policy("nat", "OUTPUT").is_ok());
+    // raw
+    assert!(ipt.get_policy("raw", "PREROUTING").is_ok());
+    assert!(ipt.get_policy("raw", "OUTPUT").is_ok());
+    // security
+    assert!(ipt.get_policy("security", "INPUT").is_ok());
+    assert!(ipt.get_policy("security", "OUTPUT").is_ok());
+    assert!(ipt.get_policy("security", "FORWARD").is_ok());
+
+    // Wrong table
+    assert!(ipt.get_policy("not_existant", "_").is_err());
+    // Wrong chain
+    assert!(ipt.get_policy("filter", "_").is_err());
+}
+
+#[test]
+#[ignore]
+fn test_set_policy() {
+    let ipt = iptables::new(false).unwrap();
+
+    // Since we can only set policies on built-in chains, we have to retain the policy of the chain
+    // before setting it, to restore it to its original state.
+    let current_policy = ipt.get_policy("mangle", "FORWARD").unwrap();
+
+    // If the following assertions fail or any other panic occurs, we still have to ensure not to
+    // change the policy for the user.
+    let result = panic::catch_unwind(|| {
+        assert_eq!(ipt.set_policy("mangle", "FORWARD", "DROP").unwrap(), true);
+        assert_eq!(ipt.get_policy("mangle", "FORWARD").unwrap(), "DROP");
+    });
+
+    // Reset the policy to the retained value
+    ipt.set_policy("mangle", "FORWARD", &current_policy).unwrap();
+
+    // "Rethrow" a potential caught panic
+    assert!(result.is_ok());
 }

--- a/tests/iptables_test.rs
+++ b/tests/iptables_test.rs
@@ -35,7 +35,9 @@ fn nat(ipt: iptables::IPTables, old_name: &str, new_name: &str) {
     assert!(ipt.execute("nat", &format!("-A {} -j ACCEPT", new_name)).is_ok());
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
+    assert_eq!(ipt.chain_exists("nat", new_name).unwrap(), true);
     assert_eq!(ipt.delete_chain("nat", new_name).unwrap(), true);
+    assert_eq!(ipt.chain_exists("nat", new_name).unwrap(), false);
 }
 
 fn filter(ipt: iptables::IPTables, name: &str) {
@@ -49,7 +51,9 @@ fn filter(ipt: iptables::IPTables, name: &str) {
     assert!(ipt.execute("filter", &format!("-A {} -j ACCEPT", name)).is_ok());
     assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.flush_chain("filter", name).unwrap(), true);
+    assert_eq!(ipt.chain_exists("filter", name).unwrap(), true);
     assert_eq!(ipt.delete_chain("filter", name).unwrap(), true);
+    assert_eq!(ipt.chain_exists("filter", name).unwrap(), false);
 }
 
 #[test]


### PR DESCRIPTION
While using this library I noticed that I lacked direct access to the iptables-instance and getting/setting the policy on a chain.

Functions I added:

* `execute`: a very thin wrapper around `run`, only specifying the table, leaving the rest to the user.

    Making `run` public might be an option, too.

* `get_policy`: get the policy for a given table and chain
* `set_policy`: set the policy for a given table and chain

I'm not sure about the names, or the implementations, just let me know if you have better ideas. 👍 