### PR TITLE
Allow quoted parameters in rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ license = "MIT"
 name = "iptables"
 
 [dependencies]
+lazy_static = "0.2.8"
 regex = "0.2"
 nix = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ impl IPTables {
     /// Executes a given `command` on the chain.
     /// Returns the command output if successful.
     pub fn execute(&self, table: &str, command: &str) -> IPTResult<Output> {
-        self.run(&[&["-t", table], command.split(" ").collect::<Vec<&str>>().as_slice()].concat())
+        self.run(&[&["-t", table], command.split_quoted().as_slice()].concat())
     }
 
     /// Checks for the existence of the `rule` in the table/chain.
@@ -164,7 +164,7 @@ impl IPTables {
             return self.exists_old_version(table, chain, rule);
         }
 
-        match self.run(&[&["-t", table, "-C", chain], rule.split(" ").collect::<Vec<&str>>().as_slice()].concat()) {
+        match self.run(&[&["-t", table, "-C", chain], rule.split_quoted().as_slice()].concat()) {
             Ok(output) => Ok(output.status.success()),
             Err(err) => Err(err),
         }
@@ -183,7 +183,7 @@ impl IPTables {
     /// Inserts `rule` in the `position` to the table/chain.
     /// Returns `true` if the rule is inserted.
     pub fn insert(&self, table: &str, chain: &str, rule: &str, position: i32) -> IPTResult<bool> {
-        match self.run(&[&["-t", table, "-I", chain, &position.to_string()], rule.split(" ").collect::<Vec<&str>>().as_slice()].concat()) {
+        match self.run(&[&["-t", table, "-I", chain, &position.to_string()], rule.split_quoted().as_slice()].concat()) {
             Ok(output) => Ok(output.status.success()),
             Err(err) => Err(err),
         }
@@ -202,7 +202,7 @@ impl IPTables {
     /// Replaces `rule` in the `position` to the table/chain.
     /// Returns `true` if the rule is replaced.
     pub fn replace(&self, table: &str, chain: &str, rule: &str, position: i32) -> IPTResult<bool> {
-        match self.run(&[&["-t", table, "-R", chain, &position.to_string()], rule.split(" ").collect::<Vec<&str>>().as_slice()].concat()) {
+        match self.run(&[&["-t", table, "-R", chain, &position.to_string()], rule.split_quoted().as_slice()].concat()) {
             Ok(output) => Ok(output.status.success()),
             Err(err) => Err(err),
         }
@@ -211,7 +211,7 @@ impl IPTables {
     /// Appends `rule` to the table/chain.
     /// Returns `true` if the rule is appended.
     pub fn append(&self, table: &str, chain: &str, rule: &str) -> IPTResult<bool> {
-        match self.run(&[&["-t", table, "-A", chain], rule.split(" ").collect::<Vec<&str>>().as_slice()].concat()) {
+        match self.run(&[&["-t", table, "-A", chain], rule.split_quoted().as_slice()].concat()) {
             Ok(output) => Ok(output.status.success()),
             Err(err) => Err(err),
         }
@@ -240,7 +240,7 @@ impl IPTables {
     /// Deletes `rule` from the table/chain.
     /// Returns `true` if the rule is deleted.
     pub fn delete(&self, table: &str, chain: &str, rule: &str) -> IPTResult<bool> {
-        match self.run(&[&["-t", table, "-D", chain], rule.split(" ").collect::<Vec<&str>>().as_slice()].concat()) {
+        match self.run(&[&["-t", table, "-D", chain], rule.split_quoted().as_slice()].concat()) {
             Ok(output) => Ok(output.status.success()),
             Err(err) => Err(err),
         }

--- a/tests/iptables_test.rs
+++ b/tests/iptables_test.rs
@@ -30,6 +30,12 @@ fn nat(ipt: iptables::IPTables, old_name: &str, new_name: &str) {
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.delete("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.insert("nat", new_name, "-j ACCEPT", 1).unwrap(), true);
+    assert_eq!(ipt.append("nat", new_name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.exists("nat", new_name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.append("nat", new_name, "-m comment --comment 'single-quoted comment' -j ACCEPT").unwrap(), true);
+    // The following `exists`-check has to use double-quotes, since the iptables output (if it
+    // doesn't have the check-functionality) will use double quotes.
+    assert_eq!(ipt.exists("nat", new_name, "-m comment --comment \"single-quoted comment\" -j ACCEPT").unwrap(), true);
     assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), false);
     assert!(ipt.execute("nat", &format!("-A {} -j ACCEPT", new_name)).is_ok());
@@ -50,6 +56,12 @@ fn filter(ipt: iptables::IPTables, name: &str) {
     assert_eq!(ipt.list("filter", name).unwrap().len(), 1);
     assert!(ipt.execute("filter", &format!("-A {} -j ACCEPT", name)).is_ok());
     assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.append("filter", name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.exists("filter", name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(ipt.append("filter", name, "-m comment --comment 'single-quoted comment' -j ACCEPT").unwrap(), true);
+    // The following `exists`-check has to use double-quotes, since the iptables output (if it
+    // doesn't have the check-functionality) will use double quotes.
+    assert_eq!(ipt.exists("filter", name, "-m comment --comment \"single-quoted comment\" -j ACCEPT").unwrap(), true);
     assert_eq!(ipt.flush_chain("filter", name).unwrap(), true);
     assert_eq!(ipt.chain_exists("filter", name).unwrap(), true);
     assert_eq!(ipt.delete_chain("filter", name).unwrap(), true);


### PR DESCRIPTION
This PR adds a `SplitQuoted` trait which adds the `split_quoted` function to `str`. This function allows to split a string on spaces, but keeping double-quoted parts intact. E.g.:

    this is "a test" string

will be split as

    ["this", "is", "a test", "string"].

Double-quotes are removed, since they will be inserted by `Command` automatically if needed.

`split_quoted` is then used where applicable. This allows rules to contain quotes. This can be necessary if one wants to use for example the rule-comment module (see also the added tests):

    -m comment --comment "a comment to describe this rule" -j ACCEPT

becomes

    ["-m", "comment", "--comment", "a comment to describe this rule", "-j", "ACCEPT"]

-----

@yaa110 let me know what you think!