### PR TITLE
Add and return PermissionDenied error when not root

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ impl error::Error for IPTError {
             IPTError::Regex(ref err) => err.description(),
             IPTError::Nix(ref err) => err.description(),
             IPTError::Parse(ref err) => err.description(),
-            IPTError::BadExitStatus(_) => "iptables exited with a non-zero status.",
+            IPTError::BadExitStatus(_) => "iptables exited with a non-zero status",
             IPTError::Other(ref message) => message,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum IPTError {
     Regex(regex::Error),
     Nix(nix::Error),
     Parse(num::ParseIntError),
+    BadExitStatus(i32),
     Other(&'static str),
 }
 
@@ -23,6 +24,7 @@ impl fmt::Display for IPTError {
             IPTError::Regex(ref err) => write!(f, "{}", err),
             IPTError::Nix(ref err) => write!(f, "{}", err),
             IPTError::Parse(ref err) => write!(f, "{}", err),
+            IPTError::BadExitStatus(i) => write!(f, "{}", i),
             IPTError::Other(ref message) => write!(f, "{}", message),
         }
     }
@@ -35,6 +37,7 @@ impl error::Error for IPTError {
             IPTError::Regex(ref err) => err.description(),
             IPTError::Nix(ref err) => err.description(),
             IPTError::Parse(ref err) => err.description(),
+            IPTError::BadExitStatus(_) => "iptables exited with a non-zero status.",
             IPTError::Other(ref message) => message,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
-extern crate regex;
 extern crate nix;
+extern crate regex;
 
-use std::{fmt, error, io, convert, num};
+use std::{convert, error, fmt, io, num};
 
 /// Defines the general error type of iptables crate
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,10 +164,8 @@ impl IPTables {
             ));
         }
 
-        match self.run(&["-t", table, "-P", chain, policy]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-P", chain, policy])
+            .and_then(|_| Ok(()))
     }
 
     /// Executes a given `command` on the chain.
@@ -206,16 +204,14 @@ impl IPTables {
     /// Inserts `rule` in the `position` to the table/chain.
     /// Returns `true` if the rule is inserted.
     pub fn insert(&self, table: &str, chain: &str, rule: &str, position: i32) -> IPTResult<()> {
-        match self.run(
+        self.run(
             &[
                 &["-t", table, "-I", chain, &position.to_string()],
                 rule.split_quoted().as_slice(),
             ]
             .concat(),
-        ) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        )
+        .and_then(|_| Ok(()))
     }
 
     /// Inserts `rule` in the `position` to the table/chain if it does not exist.
@@ -237,25 +233,21 @@ impl IPTables {
     /// Replaces `rule` in the `position` to the table/chain.
     /// Returns `true` if the rule is replaced.
     pub fn replace(&self, table: &str, chain: &str, rule: &str, position: i32) -> IPTResult<()> {
-        match self.run(
+        self.run(
             &[
                 &["-t", table, "-R", chain, &position.to_string()],
                 rule.split_quoted().as_slice(),
             ]
             .concat(),
-        ) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        )
+        .and_then(|_| Ok(()))
     }
 
     /// Appends `rule` to the table/chain.
     /// Returns `true` if the rule is appended.
     pub fn append(&self, table: &str, chain: &str, rule: &str) -> IPTResult<()> {
-        match self.run(&[&["-t", table, "-A", chain], rule.split_quoted().as_slice()].concat()) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&[&["-t", table, "-A", chain], rule.split_quoted().as_slice()].concat())
+            .and_then(|_| Ok(()))
     }
 
     /// Appends `rule` to the table/chain if it does not exist.
@@ -281,10 +273,8 @@ impl IPTables {
     /// Deletes `rule` from the table/chain.
     /// Returns `true` if the rule is deleted.
     pub fn delete(&self, table: &str, chain: &str, rule: &str) -> IPTResult<()> {
-        match self.run(&[&["-t", table, "-D", chain], rule.split_quoted().as_slice()].concat()) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&[&["-t", table, "-D", chain], rule.split_quoted().as_slice()].concat())
+            .and_then(|_| Ok(()))
     }
 
     /// Deletes all repetition of the `rule` from the table/chain.
@@ -322,37 +312,26 @@ impl IPTables {
     /// Creates a new user-defined chain.
     /// Returns `true` if the chain is created.
     pub fn new_chain(&self, table: &str, chain: &str) -> IPTResult<()> {
-        match self.run(&["-t", table, "-N", chain]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-N", chain]).and_then(|_| Ok(()))
     }
 
     /// Flushes (deletes all rules) a chain.
     /// Returns `true` if the chain is flushed.
     pub fn flush_chain(&self, table: &str, chain: &str) -> IPTResult<()> {
-        match self.run(&["-t", table, "-F", chain]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-F", chain]).and_then(|_| Ok(()))
     }
 
     /// Renames a chain in the table.
     /// Returns `true` if the chain is renamed.
     pub fn rename_chain(&self, table: &str, old_chain: &str, new_chain: &str) -> IPTResult<()> {
-        match self.run(&["-t", table, "-E", old_chain, new_chain]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-E", old_chain, new_chain])
+            .and_then(|_| Ok(()))
     }
 
     /// Deletes a user-defined chain in the table.
     /// Returns `true` if the chain is deleted.
     pub fn delete_chain(&self, table: &str, chain: &str) -> IPTResult<()> {
-        match self.run(&["-t", table, "-X", chain]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-X", chain]).and_then(|_| Ok(()))
     }
 
     /// Flushes all chains in a table.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,10 +358,7 @@ impl IPTables {
     /// Flushes all chains in a table.
     /// Returns `true` if the chains are flushed.
     pub fn flush_table(&self, table: &str) -> IPTResult<()> {
-        match self.run(&["-t", table, "-F"]) {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        }
+        self.run(&["-t", table, "-F"]).and_then(|_| Ok(()))
     }
 
     fn exists_old_version(&self, table: &str, chain: &str, rule: &str) -> IPTResult<bool> {

--- a/tests/iptables_test.rs
+++ b/tests/iptables_test.rs
@@ -10,17 +10,24 @@ fn test_new() {
 
 #[test]
 fn test_old() {
-    nat(iptables::IPTables{
-        cmd: "iptables",
-        has_wait: false,
-        has_check: false,
-    }, "NATOLD", "NATOLD2");
+    nat(
+        iptables::IPTables {
+            cmd: "iptables",
+            has_wait: false,
+            has_check: false,
+        },
+        "NATOLD",
+        "NATOLD2",
+    );
 
-    filter(iptables::IPTables{
-        cmd: "iptables",
-        has_wait: false,
-        has_check: false,
-    }, "FILTEROLD");
+    filter(
+        iptables::IPTables {
+            cmd: "iptables",
+            has_wait: false,
+            has_check: false,
+        },
+        "FILTEROLD",
+    );
 }
 
 fn nat(ipt: iptables::IPTables, old_name: &str, new_name: &str) {
@@ -30,15 +37,49 @@ fn nat(ipt: iptables::IPTables, old_name: &str, new_name: &str) {
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.delete("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.insert("nat", new_name, "-j ACCEPT", 1).unwrap(), true);
-    assert_eq!(ipt.append("nat", new_name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
-    assert_eq!(ipt.exists("nat", new_name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
-    assert_eq!(ipt.append("nat", new_name, "-m comment --comment 'single-quoted comment' -j ACCEPT").unwrap(), true);
+    assert_eq!(
+        ipt.append(
+            "nat",
+            new_name,
+            "-m comment --comment \"double-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
+    assert_eq!(
+        ipt.exists(
+            "nat",
+            new_name,
+            "-m comment --comment \"double-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
+    assert_eq!(
+        ipt.append(
+            "nat",
+            new_name,
+            "-m comment --comment 'single-quoted comment' -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
     // The following `exists`-check has to use double-quotes, since the iptables output (if it
     // doesn't have the check-functionality) will use double quotes.
-    assert_eq!(ipt.exists("nat", new_name, "-m comment --comment \"single-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(
+        ipt.exists(
+            "nat",
+            new_name,
+            "-m comment --comment \"single-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
     assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), false);
-    assert!(ipt.execute("nat", &format!("-A {} -j ACCEPT", new_name)).is_ok());
+    assert!(ipt
+        .execute("nat", &format!("-A {} -j ACCEPT", new_name))
+        .is_ok());
     assert_eq!(ipt.exists("nat", new_name, "-j ACCEPT").unwrap(), true);
     assert_eq!(ipt.flush_chain("nat", new_name).unwrap(), true);
     assert_eq!(ipt.chain_exists("nat", new_name).unwrap(), true);
@@ -54,14 +95,48 @@ fn filter(ipt: iptables::IPTables, name: &str) {
     assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), false);
     assert_eq!(ipt.delete("filter", name, "-j DROP").unwrap(), true);
     assert_eq!(ipt.list("filter", name).unwrap().len(), 1);
-    assert!(ipt.execute("filter", &format!("-A {} -j ACCEPT", name)).is_ok());
+    assert!(ipt
+        .execute("filter", &format!("-A {} -j ACCEPT", name))
+        .is_ok());
     assert_eq!(ipt.exists("filter", name, "-j ACCEPT").unwrap(), true);
-    assert_eq!(ipt.append("filter", name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
-    assert_eq!(ipt.exists("filter", name, "-m comment --comment \"double-quoted comment\" -j ACCEPT").unwrap(), true);
-    assert_eq!(ipt.append("filter", name, "-m comment --comment 'single-quoted comment' -j ACCEPT").unwrap(), true);
+    assert_eq!(
+        ipt.append(
+            "filter",
+            name,
+            "-m comment --comment \"double-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
+    assert_eq!(
+        ipt.exists(
+            "filter",
+            name,
+            "-m comment --comment \"double-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
+    assert_eq!(
+        ipt.append(
+            "filter",
+            name,
+            "-m comment --comment 'single-quoted comment' -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
     // The following `exists`-check has to use double-quotes, since the iptables output (if it
     // doesn't have the check-functionality) will use double quotes.
-    assert_eq!(ipt.exists("filter", name, "-m comment --comment \"single-quoted comment\" -j ACCEPT").unwrap(), true);
+    assert_eq!(
+        ipt.exists(
+            "filter",
+            name,
+            "-m comment --comment \"single-quoted comment\" -j ACCEPT"
+        )
+        .unwrap(),
+        true
+    );
     assert_eq!(ipt.flush_chain("filter", name).unwrap(), true);
     assert_eq!(ipt.chain_exists("filter", name).unwrap(), true);
     assert_eq!(ipt.delete_chain("filter", name).unwrap(), true);
@@ -117,7 +192,8 @@ fn test_set_policy() {
     });
 
     // Reset the policy to the retained value
-    ipt.set_policy("mangle", "FORWARD", &current_policy).unwrap();
+    ipt.set_policy("mangle", "FORWARD", &current_policy)
+        .unwrap();
 
     // "Rethrow" a potential caught panic
     assert!(result.is_ok());


### PR DESCRIPTION
As discussed in https://github.com/yaa110/rust-iptables/issues/4, the current implementation does not return an error when the process does not have permission to use iptables.

Fortunately, iptables returns a special status code for permission errors:

```bash
$ sudo iptables --list foobar; echo $?
iptables: No chain/target/match by that name.
1
$ iptables --list; echo $?
Fatal: can't open lock file /run/xtables.lock: Permission denied
4
```

This patch does three things:

1. Adds the `PermissionDenied` error.
2. Maps an exit status of 4 to a `PermissionDenied` error.
3. Runs `rustfmt`.

I can see why the maintainers might not like 3). The reformat diff is pretty small so I didn't revert it. If you'd like me to revert it and or patch it in a separate commit, please ask.

Finally, I didn't add any tests to this patch. Likely the code that tests this will need to be run without `sudo` to trigger the `PermissionDenied` path. I'm not sure of the nicest way to do this so I was going to wait for the maintainers to discuss.

Thanks!