### PR TITLE
Add -n option to iptables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ pub struct IPTables {
 
     /// Indicates if iptables has -w (--wait) option
     pub has_wait: bool,
+
+    /// Indicates if iptables will be run with -n (--numeric) option
+    pub is_numeric: bool,
 }
 
 /// Returns `None` because iptables only works on linux
@@ -133,6 +136,7 @@ pub fn new(is_ipv6: bool) -> Result<IPTables, Box<dyn Error>> {
         has_wait: (v_major > 1)
             || (v_major == 1 && v_minor > 4)
             || (v_major == 1 && v_minor == 4 && v_patch > 19),
+        is_numeric: false,
     })
 }
 
@@ -146,7 +150,10 @@ impl IPTables {
             ));
         }
 
-        let stdout = self.run(&["-t", table, "-L", chain])?.stdout;
+        let stdout = match self.is_numeric {
+            false => self.run(&["-t", table, "-L", chain])?.stdout,
+            true => self.run(&["-t", table, "-L", chain, "-n"])?.stdout,
+        };
         let output = String::from_utf8_lossy(stdout.as_slice());
         for item in output.trim().split('\n') {
             let fields = item.split(' ').collect::<Vec<&str>>();
@@ -194,8 +201,12 @@ impl IPTables {
     /// Returns true if the chain exists.
     #[cfg(target_os = "linux")]
     pub fn chain_exists(&self, table: &str, chain: &str) -> Result<bool, Box<dyn Error>> {
-        self.run(&["-t", table, "-L", chain])
-            .map(|output| output.status.success())
+        match self.is_numeric {
+            false => self.run(&["-t", table, "-L", chain])
+                .map(|output| output.status.success()),
+            true => self.run(&["-t", table, "-L", chain, "-n"])
+                .map(|output| output.status.success()),
+        }
     }
 
     fn exists_old_version(
@@ -204,9 +215,14 @@ impl IPTables {
         chain: &str,
         rule: &str,
     ) -> Result<bool, Box<dyn Error>> {
-        self.run(&["-t", table, "-S"]).map(|output| {
-            String::from_utf8_lossy(&output.stdout).contains(&format!("-A {} {}", chain, rule))
-        })
+        match self.is_numeric {
+            false => self.run(&["-t", table, "-S"]).map(|output| {
+                String::from_utf8_lossy(&output.stdout).contains(&format!("-A {} {}", chain, rule))
+            }),
+            true => self.run(&["-t", table, "-S", "-n"]).map(|output| {
+                String::from_utf8_lossy(&output.stdout).contains(&format!("-A {} {}", chain, rule))
+            })
+        }
     }
 
     /// Inserts `rule` in the `position` to the table/chain.
@@ -311,12 +327,18 @@ impl IPTables {
 
     /// Lists rules in the table/chain.
     pub fn list(&self, table: &str, chain: &str) -> Result<Vec<String>, Box<dyn Error>> {
-        self.get_list(&["-t", table, "-S", chain])
+        match self.is_numeric {
+            false => self.get_list(&["-t", table, "-S", chain]),
+            true => self.get_list(&["-t", table, "-S", chain, "-n"]),
+        }        
     }
 
     /// Lists rules in the table.
     pub fn list_table(&self, table: &str) -> Result<Vec<String>, Box<dyn Error>> {
-        self.get_list(&["-t", table, "-S"])
+        match self.is_numeric {
+            false => self.get_list(&["-t", table, "-S"]),
+            true => self.get_list(&["-t", table, "-S", "-n"]),
+        }
     }
 
     /// Lists the name of each chain in the table.
@@ -374,6 +396,12 @@ impl IPTables {
             .split('\n')
             .map(String::from)
             .collect())
+    }
+
+    /// Set whether iptables is called with the -n (--numeric) option,
+    /// to avoid host name and port name lookups
+    pub fn set_numeric(&mut self, numeric: bool) {
+        self.is_numeric = numeric;
     }
 
     fn run<S: AsRef<OsStr>>(&self, args: &[S]) -> Result<Output, Box<dyn Error>> {


### PR DESCRIPTION
In some setups `iptables` takes a long time to list rules when it cannot contact a DNS server. This PR adds the ability to pass the `-n` flag to `iptables` to stop the DNS lookups happening. Obviously any listings are returned as raw IPs and un-decoded port numbers when this option is enabled.