### PR TITLE
Add `flush_tables`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,11 @@ impl IPTables {
         self.run(&["-t", table, "-F"]).and_then(output_to_result)
     }
 
+    /// Flushes table via `iptables -F` without specifying table
+    pub fn flush_tables(&self) -> Result<(), Box<dyn Error>> {
+        self.run(&["-F"]).and_then(output_to_result)
+    }
+
     fn get_list<S: AsRef<OsStr>>(&self, args: &[S]) -> Result<Vec<String>, Box<dyn Error>> {
         let stdout = self.run(args)?.stdout;
         Ok(String::from_utf8_lossy(stdout.as_slice())


### PR DESCRIPTION
Flush tables via `iptables -F` command without requiring specific tables.

A more drastic measure that can be taken instead of adding a function can be used:
```rust
pub fn flush_table(&self, table: Option<&str>) -> Result<(), Box<dyn Error>> {
    if table.is_none() {
        return self.run(&["-F"]).and_then(output_to_result);
    }
    self.run(&["-t", table, "-F"]).and_then(output_to_result)
}
```

While a _**breaking**_ change this would require people to memorize one less function, this would also be a fairly trivial fix for people to wrap `table` in their calls to `flush_table` with `Some()`.

```rust
// new call
ipt.flush_table(Some("table"));
```